### PR TITLE
added case where log_neptune is on but no valid api key is passed for ml

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -77,7 +77,7 @@ class Train:
             hparam: h_params[i] for i, hparam in enumerate(self.hparams_names)
         }
 
-        if self.log_neptune:
+        if self.log_neptune and NEPTUNE_API_TOKEN != '' and NEPTUNE_PROJECT_NAME is not None:
             # Create a Neptune run object
             run = self.init_neptune(h_params_dict)
         else:


### PR DESCRIPTION
Answer to issue #3 . The problem was that when NEPTUNE_API_TOKEN is invalid, in this case when it is the empty string ''  and log_neptune is set to True, it can't log properly to neptune using the API.